### PR TITLE
ci(publish): set build-digest-key to prevent name clashes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,5 +21,6 @@ jobs:
       registry-username: ${{ vars.QUAY_USERNAME }}
       build-file: ${{ matrix.variant }}/Dockerfile
       build-cache-key: ${{ matrix.variant }}
+      build-digest-key: ${{ matrix.variant }}
     secrets:
       registry-password: ${{ secrets.QUAY_ROBOT_TOKEN }}


### PR DESCRIPTION
use coatl-dev/workflows@v5.0.1
